### PR TITLE
Solace Spring Cloud Version Upgrade

### DIFF
--- a/cloud-stream-batch-consume/README.md
+++ b/cloud-stream-batch-consume/README.md
@@ -8,7 +8,7 @@ A batch that the binder creates is a collection of individual messages and must 
 
 To run this sample, you will need to have installed:
 
-Java 8 or Above
+Java 17 or Above
 
 ## Code Tour
 

--- a/cloud-stream-batch-consume/pom.xml
+++ b/cloud-stream-batch-consume/pom.xml
@@ -82,6 +82,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-batch-consume/pom.xml
+++ b/cloud-stream-batch-consume/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-batch-consume/pom.xml
+++ b/cloud-stream-batch-consume/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-batch-consume/pom.xml
+++ b/cloud-stream-batch-consume/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-batch-consume</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-batch-consume</name>
 	<description>Batch Consume Sample for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-batch-publish/README.md
+++ b/cloud-stream-batch-publish/README.md
@@ -7,7 +7,7 @@ Batch publishing does not require any additional configuration – it is just ho
 
 To run this sample, you will need to have installed:
 
-Java 8 or Above
+Java 17 or Above
 
 ## Code Tour
 

--- a/cloud-stream-batch-publish/pom.xml
+++ b/cloud-stream-batch-publish/pom.xml
@@ -82,6 +82,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-batch-publish/pom.xml
+++ b/cloud-stream-batch-publish/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-batch-publish/pom.xml
+++ b/cloud-stream-batch-publish/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-batch-publish/pom.xml
+++ b/cloud-stream-batch-publish/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-batch-publish</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-batch-publish</name>
 	<description>Batch Publish Sample for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-custom-queue-names/README.md
+++ b/cloud-stream-custom-queue-names/README.md
@@ -6,7 +6,7 @@ This Spring Cloud Stream sample will show how to generate custom names for queue
 
 To run this sample, you will need to have installed:
 
-Java 8 or Above
+Java 17 or Above
 
 ## Custom Queue & Error Queue names
 
@@ -16,16 +16,9 @@ The `queueNameExpression` and `errorQueueNameExpression` follow [SpEL](https://d
 
 The default SpEL expression for creating the consumer group’s queue name is here.
 ```
-(properties.solace.queueNamePrefix?.trim()?.length() > 0 ? 
-    properties.solace.queueNamePrefix.trim() + '/' : '') + 
-(properties.solace.useFamiliarityInQueueName ? 
-    (isAnonymous ? 'an' : 'wk') + '/' : '') + 
-(isAnonymous ? group?.trim() + '/' : 
-    (properties.solace.useGroupNameInQueueName ? 
-        group?.trim() + '/' : '')) + 
-(properties.solace.useDestinationEncodingInQueueName ? 
-        'plain' + '/' : '') + 
-destination.trim().replaceAll('[*>]', '_')
+'scst/' + (isAnonymous ? 'an/' : 'wk/') 
++ (group?.trim() + '/') + 'plain/' 
++ destination.trim().replaceAll('[*>]', '_')
 ```
 
 You can also specify a literal name as the queue name in `queueNameExpression` property. The SpEL expects literal names to be quoted, and the quotes need to be escaped.

--- a/cloud-stream-custom-queue-names/pom.xml
+++ b/cloud-stream-custom-queue-names/pom.xml
@@ -82,6 +82,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-custom-queue-names/pom.xml
+++ b/cloud-stream-custom-queue-names/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-custom-queue-names/pom.xml
+++ b/cloud-stream-custom-queue-names/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-custom-queue-names/pom.xml
+++ b/cloud-stream-custom-queue-names/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-custom-queue-names</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-custom-queue-names</name>
 	<description>Custom Queue Names Sample for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-custom-queue-names/src/main/resources/application.yaml
+++ b/cloud-stream-custom-queue-names/src/main/resources/application.yaml
@@ -35,12 +35,7 @@ spring:
             consumer:
               # The queue name will be: CUSTOM-QNAME-wk-myconsumergroup-manualackqueue
               queueNameExpression: >-
-                'CUSTOM-' + (properties.solace.queueNamePrefix?.trim()?.length() > 0 ? properties.solace.queueNamePrefix.trim() + '-' : '') +
-                (properties.solace.useFamiliarityInQueueName ? (isAnonymous ?
-                'an' : 'wk') + '-' : '') + (isAnonymous ? group?.trim() + '-' :
-                (properties.solace.useGroupNameInQueueName ? group?.trim() + '-'
-                : '')) + (properties.solace.useDestinationEncodingInQueueName ?
-                'plain' + '-' : '') + destination.trim().replaceAll('[*>]', '-')
+                'CUSTOM-QNAME-' + (isAnonymous ? 'an' : 'wk') + '-' +  group?.trim() + '-' + destination.trim().replaceAll('[*>]', '-')
               # The queue name will be: ERROR-QNAME-manualackqueue
               errorQueueNameExpression: '''ERROR-QNAME-'' + destination.trim().replaceAll(''[*>]'', ''-'')'
               autoBindErrorQueue: true

--- a/cloud-stream-dynamic-destination-processor/pom.xml
+++ b/cloud-stream-dynamic-destination-processor/pom.xml
@@ -53,6 +53,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/cloud-stream-dynamic-destination-processor/pom.xml
+++ b/cloud-stream-dynamic-destination-processor/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-dynamic-destination-processor</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<name>cloud-stream-dynamic-destination-processor</name>
 	<description>Sample dynamic processor for Spring Cloud Stream using Solace PubSub+ binder</description>
 

--- a/cloud-stream-dynamic-destination-processor/pom.xml
+++ b/cloud-stream-dynamic-destination-processor/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-dynamic-destination-processor/pom.xml
+++ b/cloud-stream-dynamic-destination-processor/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-dynamic-destination-processor/src/main/resources/application.yml
+++ b/cloud-stream-dynamic-destination-processor/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 spring:
   cloud:
+    function:
+      definition: functionUsingTargetDestHeader;functionUsingStreamBridge;supplierTargetDestination;supplierStreamBridge;receiveAll
     stream:
       function:
         definition: functionUsingTargetDestHeader;functionUsingStreamBridge;supplierTargetDestination;supplierStreamBridge;receiveAll

--- a/cloud-stream-function-composition/pom.xml
+++ b/cloud-stream-function-composition/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-function-composition</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<name>cloud-stream-function-composition</name>
 	<description>Sample function composition for Spring Cloud Stream using Solace PubSub+ binder</description>
 

--- a/cloud-stream-function-composition/pom.xml
+++ b/cloud-stream-function-composition/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-function-composition/pom.xml
+++ b/cloud-stream-function-composition/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-function-composition/pom.xml
+++ b/cloud-stream-function-composition/pom.xml
@@ -61,6 +61,10 @@
 			<artifactId>jackson-databind</artifactId>
 <!-- 			<version>2.7.4</version> -->
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-function-composition/src/main/resources/application.yml
+++ b/cloud-stream-function-composition/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 spring:
   cloud:
+    function:
+      definition: preProcess|process|postProcess
     stream:
       function:
         definition: preProcess|process|postProcess

--- a/cloud-stream-manual-ack/README.md
+++ b/cloud-stream-manual-ack/README.md
@@ -22,7 +22,7 @@ To demonstrate all the acknowledgement options in action, we will work with `cor
 
 To run this sample, you will need to have installed:
 
-Java 8 or Above
+Java 17 or Above
 
 ## Code Tour
 

--- a/cloud-stream-manual-ack/pom.xml
+++ b/cloud-stream-manual-ack/pom.xml
@@ -82,6 +82,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-manual-ack/pom.xml
+++ b/cloud-stream-manual-ack/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-manual-ack/pom.xml
+++ b/cloud-stream-manual-ack/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-manual-ack/pom.xml
+++ b/cloud-stream-manual-ack/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-manual-ack</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-manual-ack</name>
 	<description>Sample Manual Ackonknowledgemnt for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-null-payload-converter/README.md
+++ b/cloud-stream-null-payload-converter/README.md
@@ -10,7 +10,7 @@ Spring provides message transformation capability using `MessageConverter` featu
 
 To run this sample, you will need to have installed:
 
-Java 8 or Above
+Java 17 or Above
 
 ## Code Tour
 

--- a/cloud-stream-null-payload-converter/pom.xml
+++ b/cloud-stream-null-payload-converter/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-null-payload-converter/pom.xml
+++ b/cloud-stream-null-payload-converter/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-null-payload-converter/pom.xml
+++ b/cloud-stream-null-payload-converter/pom.xml
@@ -80,6 +80,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-null-payload-converter/pom.xml
+++ b/cloud-stream-null-payload-converter/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-null-payload-converter</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-null-payload-converter</name>
 	<description>Null Payload Handling - Sample for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-processor/pom.xml
+++ b/cloud-stream-processor/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-processor/pom.xml
+++ b/cloud-stream-processor/pom.xml
@@ -81,6 +81,10 @@
 			<artifactId>spring-cloud-stream-test-binder</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-processor/pom.xml
+++ b/cloud-stream-processor/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-processor</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-processor</name>
 	<description>Sample processor for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-processor/pom.xml
+++ b/cloud-stream-processor/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>
@@ -75,12 +75,11 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>com.vaadin.external.google</groupId>
-					<artifactId>android-json</artifactId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-binder</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/cloud-stream-sink-null-payload-converter/pom.xml
+++ b/cloud-stream-sink-null-payload-converter/pom.xml
@@ -82,6 +82,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-sink-null-payload-converter/pom.xml
+++ b/cloud-stream-sink-null-payload-converter/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-sink-null-payload-converter/pom.xml
+++ b/cloud-stream-sink-null-payload-converter/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-sink-null-payload-converter/pom.xml
+++ b/cloud-stream-sink-null-payload-converter/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-streams-sink</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-streams-sink</name>
 	<description>Sample sink for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-sink-null-payload-converter/src/main/java/com/solace/samples/spring/scs/TemperatureSink.java
+++ b/cloud-stream-sink-null-payload-converter/src/main/java/com/solace/samples/spring/scs/TemperatureSink.java
@@ -23,7 +23,6 @@ import java.util.function.Consumer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cloud.stream.annotation.StreamMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.messaging.converter.MessageConverter;
 

--- a/cloud-stream-sink-null-payload-converter/src/test/java/com/solace/samples/spring/scs/TemperatureSinkTest.java
+++ b/cloud-stream-sink-null-payload-converter/src/test/java/com/solace/samples/spring/scs/TemperatureSinkTest.java
@@ -51,7 +51,7 @@ public class TemperatureSinkTest {
 		 * 
 		 * 1. Use of Try Me! tool in the PubSub+ Manager tool
 		 * 		Publish events on the topic with empty message content
-		 * 2. Use sdkperf to publish events on the topic with emptry payload
+		 * 2. Use sdkperf to publish events on the topic with empty payload
 		 * 		./sdkperf_java.sh -cip="localhost:55554" -ptl "sensor/temperature/99" -mn 1 -mr 1 -md
 		 */
 	}

--- a/cloud-stream-sink/pom.xml
+++ b/cloud-stream-sink/pom.xml
@@ -82,6 +82,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/cloud-stream-sink/pom.xml
+++ b/cloud-stream-sink/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-sink/pom.xml
+++ b/cloud-stream-sink/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-sink/pom.xml
+++ b/cloud-stream-sink/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-sink</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>cloud-stream-sink</name>
 	<description>Sample sink for Spring Cloud Stream using Solace PubSub+ binder</description>

--- a/cloud-stream-source/pom.xml
+++ b/cloud-stream-source/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.solace.samples.spring.scs</groupId>
 	<artifactId>cloud-stream-source</artifactId>
-	<version>0.0.2-SNAPSHOT</version>
+	<version>0.0.3-SNAPSHOT</version>
 	<name>cloud-stream-source</name>
 	<description>Sample source for Spring Cloud Stream using Solace PubSub+ binder</description>
 

--- a/cloud-stream-source/pom.xml
+++ b/cloud-stream-source/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.0.5</version>
+		<version>3.0.6</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<spring-cloud.version>2022.0.2</spring-cloud.version>
-		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
+		<solace-spring-cloud-bom.version>3.0.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-source/pom.xml
+++ b/cloud-stream-source/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.6.4</version>
+		<version>3.0.5</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2021.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>2.3.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2022.0.2</spring-cloud.version>
+		<solace-spring-cloud-bom.version>3.0.0-SNAPSHOT</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>
@@ -80,12 +80,11 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-stream-test-support</artifactId>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>com.vaadin.external.google</groupId>
-					<artifactId>android-json</artifactId>
-				</exclusion>
-			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-stream-test-binder</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/spring-samples-datamodel/pom.xml
+++ b/spring-samples-datamodel/pom.xml
@@ -13,7 +13,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>    
+    <java.version>1.8</java.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
 </project>


### PR DESCRIPTION
Update Solace Spring Cloud Version to [3.0.0](https://github.com/SolaceProducts/solace-spring-cloud/releases/tag/3.0.0)
Update Solace Spring Boot Version to [2.0.0](https://github.com/SolaceProducts/solace-spring-boot/releases/tag/2.0.0)
Update Spring Boot Version to 3.0.6
Changed Minimum JDK version required to JDK17