### PR TITLE
Update the New Version of Solace Spring Boot

### DIFF
--- a/spring-boot-autoconfig-receiver/pom.xml
+++ b/spring-boot-autoconfig-receiver/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>3.0.6</version>
 		<relativePath /> 
 	</parent>
 
@@ -32,16 +32,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-jms</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.solace.spring.boot</groupId>
 			<artifactId>solace-jms-spring-boot-starter</artifactId>
-<!-- 			<version>1.0.0</version> -->
- 			<version>2.1.0</version>
+ 			<version>5.0.0</version>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/spring-boot-autoconfig-receiver/src/main/java/com/solace/samples/spring/boot/SpringBootReceiver.java
+++ b/spring-boot-autoconfig-receiver/src/main/java/com/solace/samples/spring/boot/SpringBootReceiver.java
@@ -3,9 +3,9 @@ package com.solace.samples.spring.boot;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/spring-boot-autoconfig-sender/pom.xml
+++ b/spring-boot-autoconfig-sender/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.4.RELEASE</version>
+		<version>3.0.6</version>
 		<relativePath /> 
 	</parent>
 
@@ -32,16 +32,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>org.springframework.integration</groupId>
-			<artifactId>spring-integration-jms</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.solace.spring.boot</groupId>
 			<artifactId>solace-jms-spring-boot-starter</artifactId>
-<!-- 			<version>1.0.0</version> -->
- 			<version>2.1.0</version>
+ 			<version>5.0.0</version>
 		</dependency>
 	</dependencies>
-
 </project>

--- a/spring-boot-autoconfig-sender/src/main/java/com/solace/samples/spring/boot/SpringBootSender.java
+++ b/spring-boot-autoconfig-sender/src/main/java/com/solace/samples/spring/boot/SpringBootSender.java
@@ -1,6 +1,6 @@
 package com.solace.samples.spring.boot;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
Update Solace Spring Boot Version to [2.0.0](https://github.com/SolaceProducts/solace-spring-boot/releases/tag/2.0.0)
Update Spring Boot Version to 3.0.6
Changed Minimum JDK version required to JDK17