### PR TITLE
Distributed Tracing with OpenTelemetry Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ cd cloud-streams-sink
 mvn spring-boot:run
 ```
 
-See the individual tutorials linked from the [tutorials home page](https://dev.solace.com/samples/solace-samples-spring/) for full details which can walk you through the samples, what they do, and how to correctly run them to explore Spring
+To try running individual samples with distributed tracing enabled you can use the `run.sh` script in the `cloud-stream-processor`, `cloud-stream-sink`, or `cloud-stream-source` projects. 
+* First ensure distributed tracing is enabled on your broker and you have an open telemetry collector setup to receive your traces. More info [in docs](https://docs.solace.com/Features/Distributed-Tracing/Distributed-Tracing-Overview.htm)
+* Then go into the project you'd like to run and execute the `run.sh` script! 
 
 ## Exploring the Samples
 

--- a/cloud-stream-batch-consume/pom.xml
+++ b/cloud-stream-batch-consume/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-batch-publish/pom.xml
+++ b/cloud-stream-batch-publish/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-consumer-error-handlers/pom.xml
+++ b/cloud-stream-consumer-error-handlers/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-custom-queue-names/pom.xml
+++ b/cloud-stream-custom-queue-names/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-dynamic-destination-processor/pom.xml
+++ b/cloud-stream-dynamic-destination-processor/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-function-composition/pom.xml
+++ b/cloud-stream-function-composition/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-manual-ack/pom.xml
+++ b/cloud-stream-manual-ack/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-null-payload-converter/pom.xml
+++ b/cloud-stream-null-payload-converter/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-processor/pom.xml
+++ b/cloud-stream-processor/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-processor/run.sh
+++ b/cloud-stream-processor/run.sh
@@ -1,0 +1,68 @@
+export APP_SERVICE_NAME=cloud-stream-processor
+export APP_JAR_FILE=target/${APP_SERVICE_NAME}-0.0.3-SNAPSHOT.jar
+
+export OTEL_AGENT_VERSION=1.27.0
+export JCSMP_OTEL_EXT_VERSION=1.2.0
+export SOLACE_BINDER_OTEL_EXT_VERSION=5.8.0
+export LIB_DIR=../3rdparty
+
+mkdir -p ${LIB_DIR}
+
+#Download the OpenTelemetry Java Agent, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/opentelemetry-javaagent.jar ]; then
+  echo "Downloading OpenTelemetry Java Agent"
+  curl -o ${LIB_DIR}/opentelemetry-javaagent.jar  https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/${OTEL_AGENT_VERSION}/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar
+fi
+
+#Download the Solace JCSMP OpenTelemetry Extension, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar ]; then
+  echo "Downloading Solace JCSMP OpenTelemetry Extension"
+  curl -o ${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar https://repo1.maven.org/maven2/com/solace/solace-opentelemetry-jcsmp-integration/${JCSMP_OTEL_EXT_VERSION}/solace-opentelemetry-jcsmp-integration-${JCSMP_OTEL_EXT_VERSION}.jar
+fi
+
+#Download the Solace Binder OpenTelemetry Extension, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar ]; then
+  echo "Downloading Solace Binder OpenTelemetry Extension"
+  curl -o ${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar https://repo1.maven.org/maven2/com/solace/spring/cloud/spring-cloud-stream-binder-solace-instrumentation/${SOLACE_BINDER_OTEL_EXT_VERSION}/spring-cloud-stream-binder-solace-instrumentation-${SOLACE_BINDER_OTEL_EXT_VERSION}.jar
+fi
+
+REQUIRED_FILES=(
+  "${LIB_DIR}/opentelemetry-javaagent.jar"
+  "${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar"
+  "${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar"
+  ${APP_JAR_FILE}
+)
+
+for file in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "Required jar file not found: $file"
+    exit 1
+  fi
+done
+
+#export JAVA_HOME=~/.sdkman/candidates/java/17.0.6-tem
+#export PATH=$JAVA_HOME/bin:$PATH
+
+export OTEL_DEBUG=true
+
+java -javaagent:${LIB_DIR}/opentelemetry-javaagent.jar \
+  -Dotel.javaagent.extensions=${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar,${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar \
+  -Dotel.instrumentation.common.default-enabled=false \
+  -Dotel.javaagent.debug=${OTEL_DEBUG} \
+  -Dotel.traces.exporter=otlp \
+  -Dotel.metrics.exporter=none \
+  -Dotel.logs.exporter=none \
+  -Dotel.exporter.otlp.protocol=grpc \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -Dotel.resource.attributes=service.name=${APP_SERVICE_NAME} \
+  -Dotel.service.name=${APP_SERVICE_NAME} \
+  -Dotel.propagators=solace_jcsmp_tracecontext \
+  -Dotel.bsp.schedule.delay=100 \
+  -Dotel.bsp.max.queue.size=2048 \
+  -Dotel.bsp.max.export.batch.size=5 \
+  -Dotel.bsp.export.timeout=10000 \
+  -Dotel.java.disabled.resource.providers=io.opentelemetry.instrumentation.resources.ProcessResourceProvider \
+  -Dotel.instrumentation.solace-opentelemetry-jcsmp-integration.enabled=true \
+  -Dotel.instrumentation.spring-cloud-stream-binder-solace-instrumentation.enabled=true \
+  -jar ${APP_JAR_FILE}
+

--- a/cloud-stream-sink-null-payload-converter/pom.xml
+++ b/cloud-stream-sink-null-payload-converter/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-sink/pom.xml
+++ b/cloud-stream-sink/pom.xml
@@ -14,13 +14,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-sink/run.sh
+++ b/cloud-stream-sink/run.sh
@@ -1,0 +1,68 @@
+export APP_SERVICE_NAME=cloud-stream-sink
+export APP_JAR_FILE=target/${APP_SERVICE_NAME}-0.0.3-SNAPSHOT.jar
+
+export OTEL_AGENT_VERSION=1.27.0
+export JCSMP_OTEL_EXT_VERSION=1.2.0
+export SOLACE_BINDER_OTEL_EXT_VERSION=5.8.0
+export LIB_DIR=../3rdparty
+
+mkdir -p ${LIB_DIR}
+
+#Download the OpenTelemetry Java Agent, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/opentelemetry-javaagent.jar ]; then
+  echo "Downloading OpenTelemetry Java Agent"
+  curl -o ${LIB_DIR}/opentelemetry-javaagent.jar  https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/${OTEL_AGENT_VERSION}/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar
+fi
+
+#Download the Solace JCSMP OpenTelemetry Extension, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar ]; then
+  echo "Downloading Solace JCSMP OpenTelemetry Extension"
+  curl -o ${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar https://repo1.maven.org/maven2/com/solace/solace-opentelemetry-jcsmp-integration/${JCSMP_OTEL_EXT_VERSION}/solace-opentelemetry-jcsmp-integration-${JCSMP_OTEL_EXT_VERSION}.jar
+fi
+
+#Download the Solace Binder OpenTelemetry Extension, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar ]; then
+  echo "Downloading Solace Binder OpenTelemetry Extension"
+  curl -o ${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar https://repo1.maven.org/maven2/com/solace/spring/cloud/spring-cloud-stream-binder-solace-instrumentation/${SOLACE_BINDER_OTEL_EXT_VERSION}/spring-cloud-stream-binder-solace-instrumentation-${SOLACE_BINDER_OTEL_EXT_VERSION}.jar
+fi
+
+REQUIRED_FILES=(
+  "${LIB_DIR}/opentelemetry-javaagent.jar"
+  "${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar"
+  "${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar"
+  ${APP_JAR_FILE}
+)
+
+for file in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "Required jar file not found: $file"
+    exit 1
+  fi
+done
+
+#export JAVA_HOME=~/.sdkman/candidates/java/17.0.6-tem
+#export PATH=$JAVA_HOME/bin:$PATH
+
+export OTEL_DEBUG=true
+
+java -javaagent:${LIB_DIR}/opentelemetry-javaagent.jar \
+  -Dotel.javaagent.extensions=${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar,${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar \
+  -Dotel.instrumentation.common.default-enabled=false \
+  -Dotel.javaagent.debug=${OTEL_DEBUG} \
+  -Dotel.traces.exporter=otlp \
+  -Dotel.metrics.exporter=none \
+  -Dotel.logs.exporter=none \
+  -Dotel.exporter.otlp.protocol=grpc \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -Dotel.resource.attributes=service.name=${APP_SERVICE_NAME} \
+  -Dotel.service.name=${APP_SERVICE_NAME} \
+  -Dotel.propagators=solace_jcsmp_tracecontext \
+  -Dotel.bsp.schedule.delay=100 \
+  -Dotel.bsp.max.queue.size=2048 \
+  -Dotel.bsp.max.export.batch.size=5 \
+  -Dotel.bsp.export.timeout=10000 \
+  -Dotel.java.disabled.resource.providers=io.opentelemetry.instrumentation.resources.ProcessResourceProvider \
+  -Dotel.instrumentation.solace-opentelemetry-jcsmp-integration.enabled=true \
+  -Dotel.instrumentation.spring-cloud-stream-binder-solace-instrumentation.enabled=true \
+  -jar ${APP_JAR_FILE}
+

--- a/cloud-stream-source/pom.xml
+++ b/cloud-stream-source/pom.xml
@@ -13,13 +13,13 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.4.4</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
-		<spring-cloud.version>2023.0.1</spring-cloud.version>
-		<solace-spring-cloud-bom.version>4.0.0</solace-spring-cloud-bom.version>
+		<spring-cloud.version>2024.0.0</spring-cloud.version>
+		<solace-spring-cloud-bom.version>4.8.0</solace-spring-cloud-bom.version>
 	</properties>
 
 	<dependencyManagement>

--- a/cloud-stream-source/run.sh
+++ b/cloud-stream-source/run.sh
@@ -1,0 +1,68 @@
+export APP_SERVICE_NAME=cloud-stream-source
+export APP_JAR_FILE=target/${APP_SERVICE_NAME}-0.0.3-SNAPSHOT.jar
+
+export OTEL_AGENT_VERSION=1.27.0
+export JCSMP_OTEL_EXT_VERSION=1.2.0
+export SOLACE_BINDER_OTEL_EXT_VERSION=5.8.0
+export LIB_DIR=../3rdparty
+
+mkdir -p ${LIB_DIR}
+
+#Download the OpenTelemetry Java Agent, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/opentelemetry-javaagent.jar ]; then
+  echo "Downloading OpenTelemetry Java Agent"
+  curl -o ${LIB_DIR}/opentelemetry-javaagent.jar  https://repo1.maven.org/maven2/io/opentelemetry/javaagent/opentelemetry-javaagent/${OTEL_AGENT_VERSION}/opentelemetry-javaagent-${OTEL_AGENT_VERSION}.jar
+fi
+
+#Download the Solace JCSMP OpenTelemetry Extension, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar ]; then
+  echo "Downloading Solace JCSMP OpenTelemetry Extension"
+  curl -o ${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar https://repo1.maven.org/maven2/com/solace/solace-opentelemetry-jcsmp-integration/${JCSMP_OTEL_EXT_VERSION}/solace-opentelemetry-jcsmp-integration-${JCSMP_OTEL_EXT_VERSION}.jar
+fi
+
+#Download the Solace Binder OpenTelemetry Extension, if it is not already downloaded
+if [ ! -f ${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar ]; then
+  echo "Downloading Solace Binder OpenTelemetry Extension"
+  curl -o ${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar https://repo1.maven.org/maven2/com/solace/spring/cloud/spring-cloud-stream-binder-solace-instrumentation/${SOLACE_BINDER_OTEL_EXT_VERSION}/spring-cloud-stream-binder-solace-instrumentation-${SOLACE_BINDER_OTEL_EXT_VERSION}.jar
+fi
+
+REQUIRED_FILES=(
+  "${LIB_DIR}/opentelemetry-javaagent.jar"
+  "${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar"
+  "${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar"
+  ${APP_JAR_FILE}
+)
+
+for file in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$file" ]; then
+    echo "Required jar file not found: $file"
+    exit 1
+  fi
+done
+
+#export JAVA_HOME=~/.sdkman/candidates/java/17.0.6-tem
+#export PATH=$JAVA_HOME/bin:$PATH
+
+export OTEL_DEBUG=true
+
+java -javaagent:${LIB_DIR}/opentelemetry-javaagent.jar \
+  -Dotel.javaagent.extensions=${LIB_DIR}/solace-opentelemetry-jcsmp-integration.jar,${LIB_DIR}/spring-cloud-stream-binder-solace-instrumentation.jar \
+  -Dotel.instrumentation.common.default-enabled=false \
+  -Dotel.javaagent.debug=${OTEL_DEBUG} \
+  -Dotel.traces.exporter=otlp \
+  -Dotel.metrics.exporter=none \
+  -Dotel.logs.exporter=none \
+  -Dotel.exporter.otlp.protocol=grpc \
+  -Dotel.exporter.otlp.endpoint=http://localhost:4317 \
+  -Dotel.resource.attributes=service.name=${APP_SERVICE_NAME} \
+  -Dotel.service.name=${APP_SERVICE_NAME} \
+  -Dotel.propagators=solace_jcsmp_tracecontext \
+  -Dotel.bsp.schedule.delay=100 \
+  -Dotel.bsp.max.queue.size=2048 \
+  -Dotel.bsp.max.export.batch.size=5 \
+  -Dotel.bsp.export.timeout=10000 \
+  -Dotel.java.disabled.resource.providers=io.opentelemetry.instrumentation.resources.ProcessResourceProvider \
+  -Dotel.instrumentation.solace-opentelemetry-jcsmp-integration.enabled=true \
+  -Dotel.instrumentation.spring-cloud-stream-binder-solace-instrumentation.enabled=true \
+  -jar ${APP_JAR_FILE}
+


### PR DESCRIPTION
- Updated Solace Cloud Starter dependency BOM to v4.8.0
- Solace Cloud Starter dependency BOM v4.8.0 pull in required JCSMP v10.26.0 (minimum required JCSMP version for Solace Binder tracing)
- Added run.sh file for example opentelemetry tracing configuration

Refer: https://github.com/SolaceProducts/solace-spring-cloud/blob/master/solace-spring-cloud-stream-binder-opentelemetry/README.adoc

@gvensan @Mrc0113 